### PR TITLE
ChipperCash contributions merge to main

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,26 +2,28 @@ name: Roast My PR
 description: Automatic AI code reviews
 author: Zander Otavka
 branding:
-  icon: 'eye'
-  color: 'orange'
+  icon: eye
+  color: orange
 
 inputs:
   github-token:
-    description: 'GitHub token'
+    description: GitHub token
     required: true
   openai-api-key:
-    description: 'OpenAI API key'
+    description: OpenAI API key
     required: true
   openai-model:
-    description: 'OpenAI model'
+    description: OpenAI model
     required: false
-    default: 'gpt-4'
+    default: gpt-4-1106-preview	
   system-prompt:
-    description: 'Prompt sent as the system role.  Should include instructions for the review.'
+    description: Prompt sent as the system role.  Should include instructions for the review.
     required: false
     default: |
-      You are a very mean and sassy AI that is reviewing a PR. You are trying to
-      be as mean as possible, but still giving useful feedback. Roast this PR!
+      You are RoastMyPR, a sassy and sometimes mean AI that is reviewing a pull
+      request on GitHub. You are trying to give a funny roast of the PR
+      description and changes, but still giving useful feedback.  Keep the
+      review short. Just focus on the 1-3 most important things. Roast this PR!
   user-prompt-template:
     description: Template for prompt sent as the user role.
     required: false
@@ -34,7 +36,15 @@ inputs:
       ```
       {{pr.diff}}
       ```
+  max-diff-length:
+    description: Maximum length of the diff to send to OpenAI.
+    required: false
+    default: '12000'
+  review-request:
+    description: Set to `required` to wait for a review request.
+    required: false
+    default: optional
 
 runs:
-  using: 'node20'
-  main: 'main.js'
+  using: node20
+  main: main.js


### PR DESCRIPTION
This is the same code as #4, just merging from a repo branch so I can live test the workflow.

> I made a few improvements to the version of this project used at @ChipperCash.  This PR merges those changes back to the open-source version of this project and licenses the new code under MIT.
> 
> This open-sourcing of the code was approved by @triestpa over email.
> 
> # Changes
> * Tweaks a few default configurations to use GPT-4-Turbo and an improved prompt
> * Allows a configurable maximum diff length, and limits the diff size of individual files.  This allows the user to choose a diff length that will fit in their chosen model's context window while showing the model as much of the code as possible
> * Adds a new config option `review-request: required` to enable users to directly request reviews from a bot account.  This PR also includes an example for how to use this new option